### PR TITLE
Include coordinates of last move in /api/turn response

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,20 @@ Res: `{game: GAME OBJECT}` (null if a game doesn't exist)
 
 #### Turn
 
-To get the next player turn in the game.
+To get the player whose turn it is at the moment.
+
+The returned JSON includes the last move made by a player, which, if it just
+became your turn, will be the last move your opponent made. The client needs
+this value to update the local state of the board. The format of this string is
+`x,y` where x and y are integer coordinates for the cell which was last fired
+upon. At the beginning of the game, before any shots have been fired, the value
+is `-1,-1`.
 
 ```
 GET /api/turn/:username
 ```
 
-Res: `{username: STRING}`
+Res: `{username: STRING, lastMove: STRING}`
 
 #### Fire 
 

--- a/server/controllers/Turn.js
+++ b/server/controllers/Turn.js
@@ -5,7 +5,7 @@ exports.nextPlayer = function(req, res) {
 
   GameController.findGame(player).then(function(game) {
     if (game != null) {
-      res.json({username: game.next});
+      res.json({username: game.next, lastMove: game.lastMove});
     } else {
       res.json({message: 'No game was found.'});
     }

--- a/server/models/Game.js
+++ b/server/models/Game.js
@@ -1,8 +1,13 @@
+function coordinatesToString(x, y) {
+  return x + ',' + y;
+}
+
 module.exports = function(sequelize, DataTypes) {
   var Game = sequelize.define('Game', {
     player1: {type: DataTypes.STRING},
     player2: {type: DataTypes.STRING},
     next: {type: DataTypes.STRING},
+    lastMove: {type: DataTypes.STRING, allowNull: false, defaultValue: '-1,-1'},
     finished: {type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false}
   }, {
 
@@ -16,18 +21,19 @@ module.exports = function(sequelize, DataTypes) {
       fire: function (player, x, y) {
         if (player === this.player1) {
           this.next = this.player2;
+          this.lastMove = coordinatesToString(x, y);
           this.save();
 
           return this.Boards[1].fire(x, y);
         } else if (player === this.player2) {
           this.next = this.player1;
+          this.lastMove = coordinatesToString(x, y);
           this.save();
 
           return this.Boards[0].fire(x, y);
         }
       }
     }
-
   });
 
   return Game;


### PR DESCRIPTION
Include the coordinates of the last cell which was fired upon in the
response to /api/turn requests so that the client can update its local
board.
