### PR TITLE
Fix cell marking and fire mechamism

### DIFF
--- a/client/core/src/com/mygdx/seabattle/views/BoardGUI.java
+++ b/client/core/src/com/mygdx/seabattle/views/BoardGUI.java
@@ -25,9 +25,9 @@ public class BoardGUI extends Table {
     private final String[] letters = new String[] {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"};
     private boolean opponentBoard, smallBoard;
     private Board board;
-    private boolean init; // First draw
-    private boolean markCell; // Whether or not to mark a cell on draw
-    private boolean cellIsMarked; // Whether or not a cell is marked on the board
+    private boolean init; // True when drawing the board the first time
+    private boolean markCell; // Whether or not to mark a cell when drawing
+    private boolean cellIsMarked; // Whether or not a cell is currently marked on the board
 
     /**
      * Constructor
@@ -96,6 +96,7 @@ public class BoardGUI extends Table {
             cellSize /= 2;
         }
         smallBoard = !smallBoard;
+        // For keeping a cell marked when switching boards
         if (cellIsMarked) {
             markCell = true;
         }
@@ -180,6 +181,9 @@ public class BoardGUI extends Table {
 
     public void setBoard(Board board) {
         this.board = board;
+        if (cellIsMarked) {
+            markCell = true;
+        }
         drawCells();
     }
 

--- a/client/core/src/com/mygdx/seabattle/views/BoardGUI.java
+++ b/client/core/src/com/mygdx/seabattle/views/BoardGUI.java
@@ -25,9 +25,9 @@ public class BoardGUI extends Table {
     private final String[] letters = new String[] {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"};
     private boolean opponentBoard, smallBoard;
     private Board board;
-    private boolean init;
-    private boolean markCell;
-    private boolean cellIsMarked;
+    private boolean init; // First draw
+    private boolean markCell; // Whether or not to mark a cell on draw
+    private boolean cellIsMarked; // Whether or not a cell is marked on the board
 
     /**
      * Constructor
@@ -88,6 +88,7 @@ public class BoardGUI extends Table {
         return markedColumn;
     }
 
+    // Change the size the board is drawn
     public void toggleSize() {
         if(smallBoard) {
             cellSize *= 2;

--- a/client/core/src/com/mygdx/seabattle/views/BoardGUI.java
+++ b/client/core/src/com/mygdx/seabattle/views/BoardGUI.java
@@ -27,6 +27,7 @@ public class BoardGUI extends Table {
     private Board board;
     private boolean init;
     private boolean markCell;
+    private boolean cellIsMarked;
 
     /**
      * Constructor
@@ -52,7 +53,10 @@ public class BoardGUI extends Table {
         if(smallBoard) {
             cellSize /=2;
         }
+        cellIsMarked = false;
         markCell = false;
+        markedRow = -1;
+        markedColumn = -1;
         init = true;
         drawCells();
         init = false;
@@ -91,6 +95,9 @@ public class BoardGUI extends Table {
             cellSize /= 2;
         }
         smallBoard = !smallBoard;
+        if (cellIsMarked) {
+            markCell = true;
+        }
         drawCells();
     }
 
@@ -112,6 +119,7 @@ public class BoardGUI extends Table {
         }
         this.row();
 
+        cellIsMarked = false;
         // Make labels for the letters on the left side of the board and draw the cells
         for(int i = 0; i < 10; i++) {
             label = new Label(letters[i], gameScreen.getSkin());
@@ -133,6 +141,7 @@ public class BoardGUI extends Table {
                 else if(!init && (i == markedRow && j == markedColumn && markCell)) {
                     drawCell(i, j, oceanMarkedTex);
                     markCell = false;
+                    cellIsMarked = true;
                 }
                 else {
                     drawCell(i,j, oceanTex);
@@ -147,6 +156,10 @@ public class BoardGUI extends Table {
 
             }
             this.row();
+        }
+        if (!cellIsMarked) {
+            markedColumn = -1;
+            markedRow = -1;
         }
     }
 

--- a/client/core/src/com/mygdx/seabattle/views/GameScreen.java
+++ b/client/core/src/com/mygdx/seabattle/views/GameScreen.java
@@ -27,6 +27,7 @@ public class GameScreen implements Screen {
     private String playerName;
     private String opponentName;
     private boolean opponentIsMainView;
+    private int lastFireX, lastFireY;
 
     /**
      * Constructor
@@ -53,7 +54,7 @@ public class GameScreen implements Screen {
         gameLabel = new Label(playerName + " vs " + opponentName, skin);
         drawButtons();
         drawBoards();
-        drawOpponentLabel(opponentName);
+        drawOpponentLabel("Opponent: " + opponentName);
         drawGameLabel();
         waitForTurn();
     }
@@ -160,14 +161,18 @@ public class GameScreen implements Screen {
     public void btnFireClicked() {
         int x = getOpponentBoard().getMarkedColumn();
         int y = getOpponentBoard().getMarkedRow();
+        // x,y = (-1,-1) at init and when no cell is marked
+        if (x == -1 || y == -1) {
+            return;
+        }
         game.getGameNetworkController().getPlayerController().fireAtLocation(x, y);
     }
 
     public void changeBoardLabel() {
         if (opponentIsMainView) {
-            boardLabel.setText(opponentName);
+            boardLabel.setText("Opponent: " + opponentName);
         } else {
-            boardLabel.setText(playerName);
+            boardLabel.setText("You: " + playerName);
         }
     }
 

--- a/client/core/src/com/mygdx/seabattle/views/GameScreen.java
+++ b/client/core/src/com/mygdx/seabattle/views/GameScreen.java
@@ -51,16 +51,14 @@ public class GameScreen implements Screen {
         smallBoard = new BoardGUI(this, false, true, game.getGameNetworkController().getPlayerController().getPlayer().getBoard());
 
         boardLabel = new Label("", skin);
-        gameLabel = new Label(playerName + " vs " + opponentName, skin);
         drawButtons();
         drawBoards();
         drawOpponentLabel("Opponent: " + opponentName);
-        drawGameLabel();
         waitForTurn();
     }
 
     public void waitForTurn() {
-        btnFire.setText("Wait for turn");
+        btnFire.setText("Waiting for turn");
         btnFire.setColor(Color.RED);
         btnFire.setTouchable(Touchable.disabled);
         game.getGameNetworkController().getPlayerController().waitForTurn();
@@ -145,13 +143,6 @@ public class GameScreen implements Screen {
         boardLabel.setPosition(boardLabelPosX, boardLabelPosY);
         boardLabel.setAlignment(0);
         stage.addActor(boardLabel);
-    }
-
-    public void drawGameLabel() {
-        float gameLabelPosX = game.getWidth()/2 - gameLabel.getWidth()/2;
-        float gameLabelPosY = bigBoard.getY() - 3 * border - gameLabel.getHeight() - boardLabel.getHeight();
-        gameLabel.setPosition(gameLabelPosX, gameLabelPosY);
-        stage.addActor(gameLabel);
     }
 
     public void btnQuitClicked() {

--- a/client/core/src/com/mygdx/seabattle/views/GameScreen.java
+++ b/client/core/src/com/mygdx/seabattle/views/GameScreen.java
@@ -53,7 +53,7 @@ public class GameScreen implements Screen {
         boardLabel = new Label("", skin);
         drawButtons();
         drawBoards();
-        drawOpponentLabel("Opponent: " + opponentName);
+        drawBoardLabel("Opponent: " + opponentName);
         waitForTurn();
     }
 
@@ -136,7 +136,7 @@ public class GameScreen implements Screen {
         stage.addActor(btnQuit);
     }
 
-    public void drawOpponentLabel(String text) {
+    public void drawBoardLabel(String text) {
         boardLabel.setText(text);
         float boardLabelPosX = game.getWidth()/2;
         float boardLabelPosY = bigBoard.getY() - border - boardLabel.getHeight();
@@ -167,8 +167,7 @@ public class GameScreen implements Screen {
         }
     }
 
-    // For switching between what player and opponent board
-    // Maybe this should be done automatically, depending on who's turn it is??
+    // For switching between player and opponent board
     public void btnSwitchClicked() {
         opponentIsMainView = !opponentIsMainView;
         changeBoardLabel();


### PR DESCRIPTION
Now it's not possible to fire without having marked a cell. Also, cell's
stay marked when switching boards. Add "you" or "opponent" to board
description.